### PR TITLE
added entry.link template for some feeds (e.g. youtube-rss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ like so:
     Bookmark: {title} {url} {summary}
 
 `{hashtags}` will look for tags in the feed entry and turn them into a space
-separated list of hashtags.
+separated list of hashtags. For some feeds (e.g. youtube-rss) you should use `{link}` instead of `{url}`.
 
 ## Multiple Feeds
 

--- a/feediverse.py
+++ b/feediverse.py
@@ -69,6 +69,7 @@ def get_entry(entry):
             hashtags.append('#{}'.format(t))
     return {
         'url': entry.id,
+        'link': entry.link,
         'title': entry.title,
         'summary': entry.get('summary', ''),
         'hashtags': ' '.join(hashtags),


### PR DESCRIPTION
youtube RSS (e.g. https://www.youtube.com/feeds/videos.xml?channel_id=UCsXVk37bltHxD1rDPwtNM8Q) uses link tags instead of entry.id so I added it.