### PR TITLE
Sort entries in reverse published order.

### DIFF
--- a/feediverse.py
+++ b/feediverse.py
@@ -55,6 +55,7 @@ def read_config(config_file):
 def get_feed(feed_url, last_update):
     new_entries = 0
     feed = feedparser.parse(feed_url)
+    feed.entries.sort(key=lambda e: e.published_parsed)
     for entry in feed.entries:
         e = get_entry(entry)
         if last_update is None or e['updated'] > last_update:


### PR DESCRIPTION
In a feed typically the newest entries are on top, while the older
ones should be posted first. Thus reverse the order, based on
publish date.

Closes #4.