### PR TITLE
Several enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
         template: "dot com: {title} {url}"
       - url: https://example.org/feed/
         template: "dot org: {title} {url}"
+        generator: wordpress
 
 
 ## Special Handling for Different Feed Generators
@@ -59,6 +60,14 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
 *feediverse* has support for some special cases of some feed
 generators. For example detecting the entries perma-link. Currently
 only Wordpress is handled, but others may follow.
+
+If a feed does not provide a proper *generator* entry, you can set it
+by adding a `generator:` value to the feed's configuration. See the
+seconds one in the example above.
+
+You can check whether feed provides a *generator* entry like this:
+
+  feediverse --verbose --dry-run feedverse-test.rc | grep generator
 
 
 ## Why?

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ like so:
 `{hashtags}` will look for tags in the feed entry and turn them into a space
 separated list of hashtags.
 
+`{content}` is the whole content of the feed entry (with html-tags
+stripped). Please be aware that this might easily exceed Mastodon's
+limit of 512 characters.
+
+
 ## Multiple Feeds
 
 Since *feeds* is a list you can add additional feeds to watch if you want.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
       - url: https://example.org/feed/
         template: "dot org: {title} {url}"
 
+
+## Special Handling for Different Feed Generators
+
+*feediverse* has support for some special cases of some feed
+generators. For example detecting the entries perma-link. Currently
+only Wordpress is handled, but others may follow.
+
+
 ## Why?
 
 I created *feediverse* because I wanted to send my Pinboard bookmarks to

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Once *feediverse* is configured you can add it to your crontab:
 
     */15 * * * * /usr/local/bin/feediverse    
 
+Run `feediverse --help` to show the comand line options.
+
+
 ## Post Format
 
 You can customize the post format by opening the configuration file (default is

--- a/feediverse.py
+++ b/feediverse.py
@@ -67,7 +67,7 @@ def main():
                         (k, v.encode("utf-8") if hasattr(v, "encode") else v)
                         for k, v in entry.items()))
             if args.dry_run:
-                print("trial run, not tooting")
+                print("trial run, not tooting ", entry["title"][:50])
                 continue
             media_ids = []
             for img in entry.get("images", []):

--- a/feediverse.py
+++ b/feediverse.py
@@ -175,7 +175,11 @@ def collect_images(entry, generator=None):
 def get_entry(entry, include_images, generator=None):
 
     def cleanup(text):
-        text = BeautifulSoup(text, 'html.parser').get_text()
+        html = BeautifulSoup(text, 'html.parser')
+        # Remove all elements of class read-more or read-more-*
+        for more in html.find_all(None, re.compile("^read-more($|-.*)")):
+            more.extract()
+        text = html.get_text()
         text = re.sub('\xa0+', ' ', text)
         text = re.sub('  +', ' ', text)
         text = re.sub(' +\n', '\n', text)

--- a/feediverse.py
+++ b/feediverse.py
@@ -61,9 +61,10 @@ def main():
                               media_ids=media_ids)
     save_config(config, config_file)
 
-def save_config(config, config_file):
+def save_config(config, config_file, toot_old_posts=False):
     copy = dict(config)
-    copy['updated'] = datetime.now(tz=timezone.utc).isoformat()
+    if not toot_old_posts:
+        copy['updated'] = datetime.now(tz=timezone.utc).isoformat()
     with open(config_file, 'w') as fh:
         fh.write(yaml.dump(copy, default_flow_style=False))
 
@@ -196,6 +197,7 @@ def setup(config_file):
         access_token = m.log_in(username, password)
 
     feed_url = input('RSS/Atom feed URL to watch: ')
+    old_posts = yes_no('Shall already existing entries be tooted, too?')
     config = {
         'name': name,
         'url': url,
@@ -206,7 +208,7 @@ def setup(config_file):
             {'url': feed_url, 'template': '{title} {url}'}
         ]
     }
-    save_config(config, config_file)
+    save_config(config, config_file, old_posts)
     print("")
     print("Your feediverse configuration has been saved to {}".format(config_file))
     print("Add a line line this to your crontab to check every 15 minutes:")

--- a/feediverse.py
+++ b/feediverse.py
@@ -58,12 +58,15 @@ def read_config(config_file):
 def get_feed(feed_url, last_update):
     new_entries = 0
     feed = feedparser.parse(feed_url)
-    feed.entries.sort(key=lambda e: e.published_parsed)
-    for entry in feed.entries:
-        e = get_entry(entry)
-        if last_update is None or e['updated'] > last_update:
-            new_entries += 1
-            yield e
+    if last_update:
+        entries = [e for e in feed.entries
+                   if dateutil.parser.parse(e['updated']) > last_update]
+    else:
+        entries = feed.entries
+    entries.sort(key=lambda e: e.published_parsed)
+    for entry in entries:
+        new_entries += 1
+        yield get_entry(entry)
     return new_entries
 
 def get_entry(entry):

--- a/feediverse.py
+++ b/feediverse.py
@@ -100,9 +100,10 @@ def read_config(config_file):
 
 def detect_generator(feed):
     # For RSS the generator tag holds the URL, while for ATOM it holds the name
-    if "/wordpress.org/" in feed.feed.generator:
+    generator = feed.feed.get("generator", "")
+    if "/wordpress.org/" in generator:
         return "wordpress"
-    elif "wordpress" == feed.feed.generator.lower():
+    elif "wordpress" == generator.lower():
         return "wordpress"
     return None
 

--- a/feediverse.py
+++ b/feediverse.py
@@ -130,6 +130,7 @@ def get_entry(entry, generator=None):
         for t in tag['term'].split():
             hashtags.append('#' + t)
     summary = entry.get('summary', '')
+    content = entry.get('content', '')
     url = entry.id
     if generator == "wordpress":
         links = [l for l in entry.links if l.get("rel") == "alternate"]
@@ -141,6 +142,7 @@ def get_entry(entry, generator=None):
         'url': url,
         'title': BeautifulSoup(entry.title, 'html.parser').get_text(),
         'summary': BeautifulSoup(summary, 'html.parser').get_text(),
+        'content': BeautifulSoup(summary, 'html.parser').get_text(),
         'hashtags': ' '.join(hashtags),
         'updated': dateutil.parser.parse(entry['updated']),
         'images': collect_images(entry),

--- a/feediverse.py
+++ b/feediverse.py
@@ -32,6 +32,8 @@ def main():
     parser.add_argument("-n", "--dry-run", action="store_true",
                         help=("perform a trial run with no changes made: "
                               "don't toot, don't save config"))
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="be verbose")
     parser.add_argument("config_file", nargs="?", metavar="CONFIG-FILE",
                         help=("config file to use, default: %s" %
                               DEFAULT_CONFIG_FILE),
@@ -54,6 +56,8 @@ def main():
     for feed in config['feeds']:
         for entry in get_feed(feed['url'], config['updated'],
                               config['include_images']):
+            if args.verbose:
+                print(entry)
             if args.dry_run:
                 print("trial run, not tooting")
                 continue
@@ -69,6 +73,8 @@ def main():
     if args.dry_run:
         print("trial run, not saving the config")
     else:
+        if args.verbose:
+            print("saving the config")
         save_config(config, config_file)
 
 

--- a/feediverse.py
+++ b/feediverse.py
@@ -130,8 +130,15 @@ def get_entry(entry, generator=None):
         for t in tag['term'].split():
             hashtags.append('#' + t)
     summary = entry.get('summary', '')
+    url = entry.id
+    if generator == "wordpress":
+        links = [l for l in entry.links if l.get("rel") == "alternate"]
+        if len(links) > 1:
+            links = [l for l in entry.links if l.get("type") == "text/html"]
+        if links:
+            url = links[0]["href"]
     return {
-        'url': entry.id,
+        'url': url,
         'title': BeautifulSoup(entry.title, 'html.parser').get_text(),
         'summary': BeautifulSoup(summary, 'html.parser').get_text(),
         'hashtags': ' '.join(hashtags),

--- a/feediverse.py
+++ b/feediverse.py
@@ -123,6 +123,7 @@ def collect_images(entry, generator=None):
             e["href"] not in urls):
             urls.append(e["href"])
     if generator == "wordpress":
+        urls = (u for u in urls if not "/wp-content/plugins/" in u)
         # Work around a wordpress bug: If the filename contains an
         # umlaut, this will not be encoded using %-escape, as the
         # standard demands. This will break encoding in http.request()

--- a/feediverse.py
+++ b/feediverse.py
@@ -56,7 +56,8 @@ def main():
 
     for feed in config['feeds']:
         for entry in get_feed(feed['url'], config['updated'],
-                              config['include_images']):
+                              config['include_images'],
+                              generator=feed.get('generator')):
             if args.verbose:
                 print(entry)
             if args.dry_run:
@@ -107,7 +108,7 @@ def detect_generator(feed):
         return "wordpress"
     return None
 
-def get_feed(feed_url, last_update, include_images):
+def get_feed(feed_url, last_update, include_images, generator=None):
     new_entries = 0
     feed = feedparser.parse(feed_url)
     if last_update:
@@ -116,7 +117,7 @@ def get_feed(feed_url, last_update, include_images):
     else:
         entries = feed.entries
     entries.sort(key=lambda e: e.published_parsed)
-    generator = detect_generator(feed)
+    generator = generator or detect_generator(feed)
     for entry in entries:
         new_entries += 1
         yield get_entry(entry, include_images, generator)
@@ -198,6 +199,7 @@ def get_entry(entry, include_images, generator=None):
         'hashtags': ' '.join(hashtags),
         'updated': dateutil.parser.parse(entry['updated']),
         'images': collect_images(entry, generator) if include_images else [],
+        '__generator__': generator,
     }
 
 def setup(config_file):

--- a/feediverse.py
+++ b/feediverse.py
@@ -10,7 +10,7 @@ import feedparser
 from bs4 import BeautifulSoup
 
 from mastodon import Mastodon
-from datetime import datetime, timezone
+from datetime import datetime, timezone, MINYEAR
 import urllib3
 
 
@@ -73,7 +73,8 @@ def read_config(config_file):
         if 'updated' in config:
             config['updated'] = dateutil.parser.parse(config['updated'])
         else:
-            config['updated'] = datetime.now(tz=timezone.utc)
+            config['updated'] = datetime(MINYEAR, 1, 1,
+                                         0, 0, 0, 0, timezone.utc)
     return config
 
 def detect_generator(feed):

--- a/feediverse.py
+++ b/feediverse.py
@@ -169,7 +169,9 @@ def get_entry(entry, include_images, generator=None):
         for t in tag['term'].split():
             hashtags.append('#' + t)
     summary = entry.get('summary', '')
-    content = entry.get('content', '')
+    content = entry.get('content', '') or ''
+    if content:
+        content = content[0].get('value', '')
     url = entry.id
     if generator == "wordpress":
         links = [l for l in entry.links if l.get("rel") == "alternate"]
@@ -181,7 +183,7 @@ def get_entry(entry, include_images, generator=None):
         'url': url,
         'title': BeautifulSoup(entry.title, 'html.parser').get_text(),
         'summary': BeautifulSoup(summary, 'html.parser').get_text(),
-        'content': BeautifulSoup(summary, 'html.parser').get_text(),
+        'content': BeautifulSoup(content, 'html.parser').get_text(),
         'hashtags': ' '.join(hashtags),
         'updated': dateutil.parser.parse(entry['updated']),
         'images': collect_images(entry, generator) if include_images else [],

--- a/feediverse.py
+++ b/feediverse.py
@@ -6,9 +6,11 @@ import argparse
 import yaml
 import dateutil
 import feedparser
+from bs4 import BeautifulSoup
 
 from mastodon import Mastodon
 from datetime import datetime, timezone
+
 
 DEFAULT_CONFIG_FILE = os.path.join("~", ".feediverse")
 
@@ -74,10 +76,11 @@ def get_entry(entry):
     for tag in entry.get('tags', []):
         for t in tag['term'].split(' '):
             hashtags.append('#{}'.format(t))
+    summary = entry.get('summary', '')
     return {
         'url': entry.id,
-        'title': entry.title,
-        'summary': entry.get('summary', ''),
+        'title': BeautifulSoup(entry.title, 'html.parser').get_text(),
+        'summary': BeautifulSoup(summary, 'html.parser').get_text(),
         'hashtags': ' '.join(hashtags),
         'updated': dateutil.parser.parse(entry['updated']),
     }

--- a/feediverse.py
+++ b/feediverse.py
@@ -50,7 +50,7 @@ def save_config(config, config_file):
 def read_config(config_file):
     config = {}
     with open(config_file) as fh:
-        config = yaml.load(fh)
+        config = yaml.load(fh, yaml.SafeLoader)
         if 'updated' in config:
             config['updated'] = dateutil.parser.parse(config['updated'])
         else:

--- a/feediverse.py
+++ b/feediverse.py
@@ -169,9 +169,14 @@ def get_entry(entry, generator=None):
     }
 
 def setup(config_file):
+
+    def yes_no(question):
+        res = input(question + ' [y/n] ')
+        return res.lower() in "y1"
+
     url = input('What is your Mastodon Instance URL? ')
-    have_app = input('Do you have your app credentials already? [y/n] ')
-    if have_app.lower() == 'y':
+    have_app = yes_no('Do you have your app credentials already?')
+    if have_app:
         name = 'feediverse'
         client_id = input('What is your app\'s client id: ')
         client_secret = input('What is your client secret: ')

--- a/feediverse.py
+++ b/feediverse.py
@@ -15,6 +15,7 @@ import urllib3
 
 
 DEFAULT_CONFIG_FILE = os.path.join("~", ".feediverse")
+MAX_IMAGES = 4  # Mastodon allows attaching 4 images max.
 
 http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED',)
 
@@ -136,6 +137,8 @@ def collect_images(entry, generator=None):
         if resp.headers['content-type'].startswith(("image/", "video/")):
             images.append(resp)
             # IMPORTANT: Need to release_conn() later!
+            if len(images) >= MAX_IMAGES:
+                break
         else:
             resp.release_conn()
     return images

--- a/feediverse.py
+++ b/feediverse.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import argparse
 import yaml
 import dateutil
 import feedparser
@@ -9,8 +10,17 @@ import feedparser
 from mastodon import Mastodon
 from datetime import datetime, timezone
 
+DEFAULT_CONFIG_FILE = os.path.join("~", ".feediverse")
+
 def main():
-    config_file = get_config_file()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config_file", nargs="?", metavar="CONFIG-FILE",
+                        help=("config file to use, default: %s" %
+                              DEFAULT_CONFIG_FILE),
+                        default=os.path.expanduser(DEFAULT_CONFIG_FILE))
+    args = parser.parse_args()
+    config_file = args.config_file
+
     if not os.path.isfile(config_file):
         setup(config_file)        
 
@@ -28,13 +38,6 @@ def main():
             masto.status_post(feed['template'].format(**entry)[0:49999999999])
 
     save_config(config, config_file)
-
-def get_config_file():
-    if __name__ == "__main__" and len(sys.argv) > 1:
-        config_file = sys.argv[1]
-    else:
-        config_file = os.path.join(os.path.expanduser("~"), ".feediverse")
-    return config_file
 
 def save_config(config, config_file):
     copy = dict(config)

--- a/feediverse.py
+++ b/feediverse.py
@@ -59,7 +59,13 @@ def main():
                               config['include_images'],
                               generator=feed.get('generator')):
             if args.verbose:
-                print(entry)
+                try:
+                    print(entry)
+                except UnicodeEncodeError:
+                    # work-around for non-unicode terminals
+                    print(dict(
+                        (k, v.encode("utf-8") if hasattr(v, "encode") else v)
+                        for k, v in entry.items()))
             if args.dry_run:
                 print("trial run, not tooting")
                 continue

--- a/feediverse.py
+++ b/feediverse.py
@@ -69,14 +69,14 @@ def save_config(config, config_file, toot_old_posts=False):
         fh.write(yaml.dump(copy, default_flow_style=False))
 
 def read_config(config_file):
-    config = {}
+    config = {
+        'updated': datetime(MINYEAR, 1, 1, 0, 0, 0, 0, timezone.utc),
+    }
     with open(config_file) as fh:
-        config = yaml.load(fh, yaml.SafeLoader)
-        if 'updated' in config:
-            config['updated'] = dateutil.parser.parse(config['updated'])
-        else:
-            config['updated'] = datetime(MINYEAR, 1, 1,
-                                         0, 0, 0, 0, timezone.utc)
+        cfg = yaml.load(fh, yaml.SafeLoader)
+        if 'updated' in cfg:
+            cfg['updated'] = dateutil.parser.parse(cfg['updated'])
+    config.update(cfg)
     return config
 
 def detect_generator(feed):

--- a/feediverse.py
+++ b/feediverse.py
@@ -74,8 +74,8 @@ def get_feed(feed_url, last_update):
 def get_entry(entry):
     hashtags = []
     for tag in entry.get('tags', []):
-        for t in tag['term'].split(' '):
-            hashtags.append('#{}'.format(t))
+        for t in tag['term'].split():
+            hashtags.append('#' + t)
     summary = entry.get('summary', '')
     return {
         'url': entry.id,

--- a/feediverse.py
+++ b/feediverse.py
@@ -58,6 +58,7 @@ def read_config(config_file):
 def get_feed(feed_url, last_update):
     new_entries = 0
     feed = feedparser.parse(feed_url)
+    feed.entries.sort(key=lambda e: e.published_parsed)
     for entry in feed.entries:
         e = get_entry(entry)
         if last_update is None or e['updated'] > last_update:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setup(
     description='Connect an RSS Feed to Mastodon',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=['feedparser', 'mastodon.py', 'python-dateutil', 'pyyaml'],
+    install_requires=['beautifulsoup4',
+                      'feedparser',
+                      'mastodon.py',
+                      'python-dateutil',
+                      'pyyaml'],
     entry_points={'console_scripts': ['feediverse = feediverse:main']}
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
                       'feedparser',
                       'mastodon.py',
                       'python-dateutil',
-                      'pyyaml'],
+                      'pyyaml',
+                      'urllib3[secure]'],
     entry_points={'console_scripts': ['feediverse = feediverse:main']}
 )


### PR DESCRIPTION
* Sort entries in reverse published order (#4, #7)
* Add minimal argparse support to get support for `--help`. (#5, #6)
* Add options --dry-run and --verbose.
* Remove HTML tags and cleanup white-space from fetched texts.
* Add optionally retrieving images from RSS & posting them
* Add detection of feed generator and pass it for get_entry().
* Add detection of premalink for wordpress-generated feeds and other wordpress-specific handling.
* Make "content" available in the template.
* On setup ask whether existing entries shall be tooted, too.
* Update Readme.

Closes #4, #5, #6, #7.
Closes #13, #14, #15, #16.