### PR TITLE
Make `enclosures` and `links` attributes optional

### DIFF
--- a/feediverse.py
+++ b/feediverse.py
@@ -151,8 +151,8 @@ def collect_images(entry, generator=None):
     find_urls(entry.get("summary", ""))
     for c in entry.get("content", []):
         find_urls(c.value)
-    for e in (entry.enclosures
-              + [l for l in entry.links if l.get("rel") == "enclosure"]):
+    for e in (entry.get("enclosures", [])
+              + [l for l in entry.get("links", []) if l.get("rel") == "enclosure"]):
         if (e["type"].startswith(("image/", "video/")) and
             e["href"] not in urls):
             urls.append(e["href"])
@@ -204,9 +204,9 @@ def get_entry(entry, include_images, generator=None):
         content = cleanup(content[0].get('value', ''))
     url = entry.id
     if generator == "wordpress":
-        links = [l for l in entry.links if l.get("rel") == "alternate"]
+        links = [l for l in entry.get("links", []) if l.get("rel") == "alternate"]
         if len(links) > 1:
-            links = [l for l in entry.links if l.get("type") == "text/html"]
+            links = [l for l in entry.get("links", []) if l.get("type") == "text/html"]
         if links:
             url = links[0]["href"]
         t = tag['term'].replace(' ', '_').replace('.', '').replace('-', '')


### PR DESCRIPTION
Feediverse fails to process entries which do not contain the `enclosures` or `links` elements.

Traceback:
```
Traceback (most recent call last):
  File "/path/to/lib/python3.6/site-packages/feedparser/util.py", line 156, in __getattr__
    return self.__getitem__(key)
  File "/path/to/lib/python3.6/site-packages/feedparser/util.py", line 65, in __getitem__
    for link in dict.__getitem__(self, 'links')
KeyError: 'links'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./feediverse.py", line 277, in <module>
    main()
  File "./feediverse.py", line 64, in main
    generator=feed.get('generator')):
  File "./feediverse.py", line 133, in get_feed
    yield get_entry(entry, include_images, generator)
  File "./feediverse.py", line 222, in get_entry
    'images': collect_images(entry, generator) if include_images else [],
  File "./feediverse.py", line 154, in collect_images
    for e in (entry.enclosures
  File "/path/to/lib/python3.6/site-packages/feedparser/util.py", line 158, in __getattr__
    raise AttributeError("object has no attribute '%s'" % key)
AttributeError: object has no attribute 'enclosures'
```