### PR TITLE
Add support for linking to comments

### DIFF
--- a/feediverse.py
+++ b/feediverse.py
@@ -214,6 +214,7 @@ def get_entry(entry, include_images, generator=None):
     return {
         'url': url,
         'link': entry.link,
+        'comments': entry.comments,
         'title': cleanup(entry.title),
         'summary': cleanup(summary),
         'content': content,


### PR DESCRIPTION
Add the `comments` element to the parsed RSS entry to allow linking to the comments of the entry.

https://validator.w3.org/feed/docs/rss2.html#ltcommentsgtSubelementOfLtitemgt