### PR TITLE
Allow to access entry links in the template

### DIFF
--- a/feediverse.py
+++ b/feediverse.py
@@ -84,6 +84,7 @@ def get_entry(entry):
     return {
         'url': url,
         'link': entry.link,
+        'links': entry.links,
         'title': cleanup(entry.title),
         'summary': cleanup(summary),
         'content': content,


### PR DESCRIPTION
With this patch, if an entry has several links, they can be accessed this way:

```
{title} {links[0].href} {links[1].href}
```

cf. https://feedparser.readthedocs.io/en/latest/reference-entry-links.html