### PR TITLE
make it possible to include headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
       - url: https://example.org/feed/
         template: "dot org: {title} {url}"
 
+## Custom Headers
+
+if you want to include own headers you can place `custom_http_headers` in your config:
+
+    custom_http_headers: 'header1: value1, header1: value2'

--- a/README.md
+++ b/README.md
@@ -55,4 +55,8 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
 
 if you want to include own headers you can place `custom_http_headers` in your config:
 
-    custom_http_headers: 'header1: value1, header2: value2'
+    ....
+    feeds:
+      - url: https://example.com/feed/
+        template: "dot com: {title} {url}"
+        custom_http_headers: 'header1: value1, header2: value2'

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Since *feeds* is a list you can add additional feeds to watch if you want.
 
 if you want to include own headers you can place `custom_http_headers` in your config:
 
-    custom_http_headers: 'header1: value1, header1: value2'
+    custom_http_headers: 'header1: value1, header2: value2'

--- a/feediverse.py
+++ b/feediverse.py
@@ -45,16 +45,18 @@ def main():
 
     newest_post = config['updated']
 
-    try:
-        config['custom_http_headers']
-    except:
-        http_headers = ''
-    else:
-        http_headers = 'request_headers={' + config['custom_http_headers'] + '}'
-
     for feed in config['feeds']:
+
+        try:
+            feed['custom_http_headers']
+        except:
+            http_headers = ''
+        else:
+            http_headers = 'request_headers={' + config['custom_http_headers'] + '}'
+
         if args.verbose:
             print(f"fetching {feed['url']} entries since {config['updated']}")
+            print("HTTP headers: {config['custom_http_headers']}")
         for entry in get_feed(feed['url'], config['updated'], http_headers):
             newest_post = max(newest_post, entry['updated'])
             if args.verbose:

--- a/feediverse.py
+++ b/feediverse.py
@@ -48,9 +48,9 @@ def main():
     try:
         config['custom_http_headers']
     except:
-        http_headers='user_agent: feediverse'
+        http_headers=''
     else:
-        http_headers='user_agent: feediverse, ' + config['custom_http_headers']
+        http_headers='request_headers={' + config['custom_http_headers'] + '}'
 
     for feed in config['feeds']:
         if args.verbose:

--- a/feediverse.py
+++ b/feediverse.py
@@ -44,13 +44,15 @@ def main():
     )
 
     newest_post = config['updated']
+
+    try:
+        config['custom_http_headers']
+    except:
+         http_headers='user_agent: feediverse'
+    else:
+        http_headers='user_agent: feediverse, ' + config['custom_http_headers']
+
     for feed in config['feeds']:
-        try:
-            config['custom_http_headers']
-        except:
-            http_headers='user_agent: feediverse'
-        else:
-            http_headers='user_agent: feediverse, ' + config['custom_http_headers']
         if args.verbose:
             print(f"fetching {feed['url']} entries since {config['updated']}")
         for entry in get_feed(feed['url'], config['updated'], http_headers):

--- a/feediverse.py
+++ b/feediverse.py
@@ -56,7 +56,7 @@ def main():
 
         if args.verbose:
             print(f"fetching {feed['url']} entries since {config['updated']}")
-            print("HTTP headers: {config['custom_http_headers']}")
+            print("HTTP headers: {http_headers}")
         for entry in get_feed(feed['url'], config['updated'], http_headers):
             newest_post = max(newest_post, entry['updated'])
             if args.verbose:

--- a/feediverse.py
+++ b/feediverse.py
@@ -48,7 +48,7 @@ def main():
     try:
         config['custom_http_headers']
     except:
-         http_headers='user_agent: feediverse'
+        http_headers='user_agent: feediverse'
     else:
         http_headers='user_agent: feediverse, ' + config['custom_http_headers']
 

--- a/feediverse.py
+++ b/feediverse.py
@@ -48,9 +48,9 @@ def main():
     try:
         config['custom_http_headers']
     except:
-        http_headers=''
+        http_headers = ''
     else:
-        http_headers='request_headers={' + config['custom_http_headers'] + '}'
+        http_headers = 'request_headers={' + config['custom_http_headers'] + '}'
 
     for feed in config['feeds']:
         if args.verbose:


### PR DESCRIPTION
Hello,

I have included a new config param `custom_http_headers` so that it is possible to include custom headers such as `accept-language` or `cache-control`. It is not needed to set the param in the config cause not all people need it.