### PR TITLE
Add de-duping to feediverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you are attempting to use the RSS feed of a major news site, you may find
 that they change / update (or just re-post) the same items multiple times which
 will lead to duplicate toots. To enable de-duplication, use the `{--dedupe}`
 option to check for duplicates based on a tag before tooting, e.g.
+
     feediverse --dedupe url
 
 ## Multiple Feeds

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ separated list of hashtags. For some feeds (e.g. youtube-rss) you should use `{l
 stripped). Please be aware that this might easily exceed Mastodon's
 limit of 512 characters.
 
+
+## De-duping
+
+If you are attempting to use the RSS feed of a major news site, you may find
+that they change / update (or just re-post) the same items multiple times which
+will lead to duplicate toots. To enable de-duplication, use the `{--dedupe}`
+option to check for duplicates based on a tag before tooting, e.g.
+    feediverse --dedupe url
+
 ## Multiple Feeds
 
 Since *feeds* is a list you can add additional feeds to watch if you want.

--- a/feediverse.py
+++ b/feediverse.py
@@ -25,8 +25,8 @@ def main():
                         help="config file to use",
                         default=os.path.expanduser(DEFAULT_CONFIG_FILE))
     parser.add_argument("-d", "--dedupe",
-                        help="dedupe against the given field",
-                        default="")
+                        help="dedupe against the given tag",
+                        default="", metavar="TAG")
 
     args = parser.parse_args()
     config_file = args.config


### PR DESCRIPTION
Setting up some bots for scraping RSS and pushing to Mastodon recently, I notice many larger sites (e.g. CNBC) update their entries either to make updates to make changes, or just push old entries to the top. This causes feediverse to re-toot entries, sometimes several times in a row.

Added a command line flag (by default disabled) to add some basic de-duplication and maintain its state in the .feediverse file. 