### PR TITLE
Attach first 4 image URLs to the post

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 It's meant to add a little bit of spice to your timeline from other places.
 Please use it responsibly.
 
-## Install
+## Build Locally
 
-    pip install feediverse
+Check out this repository, and then run the following commands:
+
+    pip install wheel
+    pip install .
+
+[Source](https://towardsdatascience.com/building-a-python-package-without-publishing-e2d36c4686cd)
 
 ## Run
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
                       'feedparser',
                       'mastodon.py',
                       'python-dateutil',
-                      'pyyaml'],
+                      'pyyaml',
+                      'requests'],
     entry_points={'console_scripts': ['feediverse = feediverse:main']}
 )


### PR DESCRIPTION
I wanted to have my images auto-attach to the Mastodon post, as I want to post more image and description only posts.

I added a new config 'include_images' to the feed config, as well as the initial questionnaire. If this is enabled, `requests` pulls down the first 4 images found in `<i>` tags and uploads those as media via the `Mastodon.media_post(media_file, mime_type=None)` method in the Mastodon API.

I, personally, am setting up two tags on my Micro.blog, so that all my posts are defined as a photos post or a blog post, and separated into two different feeds. I then have two feeds configured in my `.feediverse` file with different templates. 
```
- template: 'New Blog Post: {title} {link} {hashtags}'
  url: https://blog.jacksampson.info/categories/syndicate/feed.xml
  include_images: false
- template: '{summary}'
  url: https://blog.jacksampson.info/categories/photos/feed.xml
  include_images: true```